### PR TITLE
New-Item -ItemType Change

### DIFF
--- a/InstallAWSPowerShellModule.ps1
+++ b/InstallAWSPowerShellModule.ps1
@@ -38,7 +38,7 @@ Function InstallAWSToolsforWindowsPowerShell() {
 
     If (!(Test-Path $DestinationFolder))
     {
-        New-Item $DestinationFolder -ItemType Folder -Force
+        New-Item $DestinationFolder -ItemType Directory -Force
     }
 
     Write-Host "Downloading AWS PowerShell Module from $AWSPowerShellModuleSourceURL"


### PR DESCRIPTION
When creating a folder, New-Item -ItemType should be "Directory" instead of "Folder".  Verified on PS 1.0, 3.0, and 5.0 documentation.
